### PR TITLE
bugfix/questionaire_screen_requests

### DIFF
--- a/lib/screens/questionaire_screen/questionaire_screen.dart
+++ b/lib/screens/questionaire_screen/questionaire_screen.dart
@@ -200,7 +200,7 @@ class _QuestionaireScreenState extends State<QuestionaireScreen> {
 
   // Class init.
   Future<bool> _classInit(BuildContext context) async {
-    if (_daily != null || _weekly != null || _phq4 != null) {
+    if (_pageStorage != null) {
       return true;
     }
 


### PR DESCRIPTION
If one of the models inside the QuestionaireScreen (Daily, Weekly, PHQ4) are null (e.g. if a new daily is to be created), then the gate codition in _classInit() wasn't met and each time you change the page the whole _classInit() method gets executed resulting in frequent getAll() requests.

This chagne should fix this.