### PR TITLE
Use the safer Random.secure() method instead of the Random() method

### DIFF
--- a/lib/models/patient.dart
+++ b/lib/models/patient.dart
@@ -104,7 +104,7 @@ class Patient extends AbstractDatabaseObject {
     // A non-negative number for determining the length of the password.
     const int length = 12;
 
-    Random randomString = Random();
+    Random randomString = Random.secure();
 
     return String.fromCharCodes(
       List<int>.generate(


### PR DESCRIPTION
Random.secure() creates a cryptographically secure random number generator.
- fixes issue #29