### PR TITLE
Change the color and visibility of the icons on the status bar for the Overview and MyPICOS 

### DIFF
--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -48,6 +48,7 @@ class AppConfig extends StatelessWidget {
               ),
           appBarTheme: AppBarTheme(
             backgroundColor: theme.darkGreen1,
+            shadowColor: Colors.transparent,
           ),
           dialogBackgroundColor: theme.darkGreen2,
           focusColor: theme.darkGreen3,

--- a/lib/screens/home_screen/home_screen.dart
+++ b/lib/screens/home_screen/home_screen.dart
@@ -89,10 +89,12 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
-    return PicosScreenFrame(
-      body: const PicosMenu(),
-      title: 'MyPICOS',
-      bottomNavigationBar: bottomNavigationBar,
+    return SafeArea(
+      child: PicosScreenFrame(
+        body: const PicosMenu(),
+        title: 'MyPICOS',
+        bottomNavigationBar: bottomNavigationBar,
+      ),
     );
   }
 

--- a/lib/screens/home_screen/home_screen.dart
+++ b/lib/screens/home_screen/home_screen.dart
@@ -89,12 +89,10 @@ class _HomeScreenState extends State<HomeScreen> {
       );
     }
 
-    return SafeArea(
-      child: PicosScreenFrame(
-        body: const PicosMenu(),
-        title: 'MyPICOS',
-        bottomNavigationBar: bottomNavigationBar,
-      ),
+    return PicosScreenFrame(
+      body: const PicosMenu(),
+      title: 'MyPICOS',
+      bottomNavigationBar: bottomNavigationBar,
     );
   }
 

--- a/lib/screens/home_screen/overview/overview.dart
+++ b/lib/screens/home_screen/overview/overview.dart
@@ -16,43 +16,87 @@
 */
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:picos/screens/home_screen/overview/widgets/contact_section.dart';
 import 'package:picos/screens/home_screen/overview/widgets/my_health_section.dart';
 import 'package:picos/screens/home_screen/overview/widgets/questionnaire_section.dart';
 import '../../../themes/global_theme.dart';
 
 /// Main widget using all subwidgets to build up the "overview"-screen
-class Overview extends StatelessWidget {
+class Overview extends StatefulWidget {
   /// OverviewScreen constructor
   const Overview({Key? key}) : super(key: key);
 
   @override
+  createState() => _OverviewState();
+}
+
+class _OverviewState extends State<Overview> {
+  final ScrollController _scrollController = ScrollController();
+  bool _isScrolled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_handleScroll);
+  }
+
+  void _handleScroll() {
+    final double appBarHeight = AppBar().preferredSize.height;
+    final double statusBarHeight = MediaQuery.of(context).padding.top;
+
+    setState(() {
+      _isScrolled =
+          _scrollController.offset >= (appBarHeight + statusBarHeight);
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.removeListener(_handleScroll);
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _setSystemNavigationBarColor(BuildContext context) {
+    SystemChrome.setSystemUIOverlayStyle(
+      SystemUiOverlayStyle(
+        statusBarColor: _isScrolled
+            ? Theme.of(context).extension<GlobalTheme>()!.darkGreen1
+            : Theme.of(context).bottomNavigationBarTheme.backgroundColor ??
+                Theme.of(context).canvasColor,
+        statusBarIconBrightness:
+            _isScrolled ? Brightness.light : Brightness.dark,
+      ),
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
     final GlobalTheme theme = Theme.of(context).extension<GlobalTheme>()!;
-
-    return SingleChildScrollView(
-      child: Column(
-        children: <Widget>[
-          const SizedBox(
-            height: 45,
-          ),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Image>[
-              Image.asset(
-                'assets/PICOS_Logo_RGB.png',
-                height: 75,
-              )
-            ],
-          ),
-          const QuestionaireSection(),
-          Container(
-            color: theme.blue,
-            child: const MyHealthSection(),
-          ),
-          const ContactSection()
-        ],
-      ),
+    _setSystemNavigationBarColor(context);
+    return ListView(
+      controller: _scrollController,
+      children: <Widget>[
+        const SizedBox(
+          height: 15,
+        ),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Image>[
+            Image.asset(
+              'assets/PICOS_Logo_RGB.png',
+              height: 75,
+            )
+          ],
+        ),
+        const QuestionaireSection(),
+        Container(
+          color: theme.blue,
+          child: const MyHealthSection(),
+        ),
+        const ContactSection()
+      ],
     );
   }
 }

--- a/lib/screens/home_screen/overview/overview.dart
+++ b/lib/screens/home_screen/overview/overview.dart
@@ -44,10 +44,10 @@ class _OverviewState extends State<Overview> {
   void _handleScroll() {
     final double appBarHeight = AppBar().preferredSize.height;
     final double statusBarHeight = MediaQuery.of(context).padding.top;
-
+    bool isScrolled =
+        _scrollController.offset >= (appBarHeight + statusBarHeight);
     setState(() {
-      _isScrolled =
-          _scrollController.offset >= (appBarHeight + statusBarHeight);
+      _isScrolled = isScrolled;
     });
   }
 

--- a/lib/screens/home_screen/overview/overview.dart
+++ b/lib/screens/home_screen/overview/overview.dart
@@ -59,14 +59,22 @@ class _OverviewState extends State<Overview> {
   }
 
   void _setSystemNavigationBarColor(BuildContext context) {
+    final Color? statusBarColorValue;
+    final Brightness? statusBarIconBrightnessValue;
+    if (_isScrolled) {
+      statusBarColorValue =
+          Theme.of(context).extension<GlobalTheme>()!.darkGreen1;
+      statusBarIconBrightnessValue = Brightness.light;
+    } else {
+      statusBarColorValue =
+          Theme.of(context).bottomNavigationBarTheme.backgroundColor ??
+              Theme.of(context).canvasColor;
+      statusBarIconBrightnessValue = Brightness.dark;
+    }
     SystemChrome.setSystemUIOverlayStyle(
       SystemUiOverlayStyle(
-        statusBarColor: _isScrolled
-            ? Theme.of(context).extension<GlobalTheme>()!.darkGreen1
-            : Theme.of(context).bottomNavigationBarTheme.backgroundColor ??
-                Theme.of(context).canvasColor,
-        statusBarIconBrightness:
-            _isScrolled ? Brightness.light : Brightness.dark,
+        statusBarColor: statusBarColorValue,
+        statusBarIconBrightness: statusBarIconBrightnessValue,
       ),
     );
   }

--- a/lib/screens/home_screen/overview/overview.dart
+++ b/lib/screens/home_screen/overview/overview.dart
@@ -34,16 +34,23 @@ class Overview extends StatefulWidget {
 class _OverviewState extends State<Overview> {
   final ScrollController _scrollController = ScrollController();
   bool _isScrolled = false;
+  double appBarHeight = 0;
+  double statusBarHeight = 0;
 
   @override
   void initState() {
     super.initState();
+
+    /// Execute the callback once after the current frame is drawn on the screen
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      appBarHeight = AppBar().preferredSize.height;
+      statusBarHeight = MediaQuery.of(context).padding.top;
+    });
+
     _scrollController.addListener(_handleScroll);
   }
 
   void _handleScroll() {
-    final double appBarHeight = AppBar().preferredSize.height;
-    final double statusBarHeight = MediaQuery.of(context).padding.top;
     bool isScrolled =
         _scrollController.offset >= (appBarHeight + statusBarHeight);
     setState(() {

--- a/lib/screens/home_screen/picos_menu/picos_menu.dart
+++ b/lib/screens/home_screen/picos_menu/picos_menu.dart
@@ -16,6 +16,7 @@
 */
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:picos/screens/home_screen/picos_menu/picos_menu_item.dart';
 import 'package:picos/widgets/picos_label.dart';
@@ -28,8 +29,18 @@ class PicosMenu extends StatelessWidget {
   /// PicosMenu constructor
   const PicosMenu({Key? key}) : super(key: key);
 
+  void _setSystemNavigationBarColor(BuildContext context) {
+    SystemChrome.setSystemUIOverlayStyle(
+      SystemUiOverlayStyle(
+        statusBarColor: Theme.of(context).appBarTheme.backgroundColor,
+        statusBarIconBrightness: Brightness.light,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    _setSystemNavigationBarColor(context);
     const double labelSize = 17;
     const double sidePadding = 15;
     const double labelPadding = 10;

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -116,7 +116,8 @@ class _LoginScreenState extends State<LoginScreen>
                     children: <TextSpan>[
                       TextSpan(
                         text:
-                            '${AppLocalizations.of(context)!.welcomeToPICOS},\n',
+                            '${AppLocalizations.of(context)!
+                                .welcomeToPICOS},\n',
                         style: const TextStyle(
                           fontWeight: FontWeight.bold,
                         ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -74,12 +74,13 @@ class _LoginScreenState extends State<LoginScreen>
   @override
   void initState() {
     super.initState();
-    SystemChrome.setSystemUIOverlayStyle(
-      SystemUiOverlayStyle(
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
         statusBarColor: Theme.of(context).canvasColor,
         statusBarIconBrightness: Brightness.dark,
-      ),
-    );
+      ));
+    });
+
     _loginController = TextEditingController(text: '');
     _passwordController = TextEditingController(text: '');
     _passwordVisible = false;
@@ -116,8 +117,7 @@ class _LoginScreenState extends State<LoginScreen>
                     children: <TextSpan>[
                       TextSpan(
                         text:
-                            '${AppLocalizations.of(context)!
-                                .welcomeToPICOS},\n',
+                            '${AppLocalizations.of(context)!.welcomeToPICOS},\n',
                         style: const TextStyle(
                           fontWeight: FontWeight.bold,
                         ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -16,10 +16,10 @@
 */
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:picos/util/backend.dart';
 import 'package:picos/widgets/picos_body.dart';
 import 'package:picos/widgets/picos_ink_well_button.dart';
-import 'package:picos/widgets/picos_screen_frame.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:picos/widgets/picos_text_field.dart';
 
@@ -86,103 +86,119 @@ class _LoginScreenState extends State<LoginScreen>
     super.dispose();
   }
 
+  void _setSystemNavigationBarColor(BuildContext context) {
+    SystemChrome.setSystemUIOverlayStyle(
+      SystemUiOverlayStyle(
+        statusBarColor: Theme.of(context).canvasColor,
+        statusBarIconBrightness: Brightness.dark,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return PicosScreenFrame(
-      body: Center(
-        child: PicosBody(
-          child: Column(
-            children: <Widget>[
-              const Image(
-                image: AssetImage('assets/PICOS_Logo_RGB.png'),
-              ),
-              RichText(
-                text: TextSpan(
-                  style: const TextStyle(
-                    height: 2,
-                    color: Colors.black,
-                  ),
-                  children: <TextSpan>[
-                    TextSpan(
-                      text:
-                          '${AppLocalizations.of(context)!.welcomeToPICOS},\n',
-                      style: const TextStyle(
-                        fontWeight: FontWeight.bold,
+    _setSystemNavigationBarColor(context);
+    return SafeArea(
+      child: Scaffold(
+        appBar: PreferredSize(
+          preferredSize: const Size.fromHeight(0.0), // here the desired height
+          child: AppBar(),
+        ),
+        body: Center(
+          child: PicosBody(
+            child: Column(
+              children: <Widget>[
+                const Image(
+                  image: AssetImage('assets/PICOS_Logo_RGB.png'),
+                ),
+                RichText(
+                  text: TextSpan(
+                    style: const TextStyle(
+                      height: 2,
+                      color: Colors.black,
+                    ),
+                    children: <TextSpan>[
+                      TextSpan(
+                        text:
+                            '${AppLocalizations.of(context)!.welcomeToPICOS},\n',
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
-                    TextSpan(
-                      text: AppLocalizations.of(context)!
-                          .thankYouForParticipation,
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(
-                height: 15,
-              ),
-              SizedBox(
-                width: 200,
-                child: PicosTextField(
-                  controller: _loginController,
-                  hint: AppLocalizations.of(context)!.username,
-                ),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              SizedBox(
-                width: 200,
-                child: PicosTextField(
-                  controller: _passwordController,
-                  hint: AppLocalizations.of(context)!.password,
-                  obscureText: !_passwordVisible,
-                  suffixIcon: IconButton(
-                    icon: Icon(
-                      _passwordVisible
-                          ? Icons.visibility_rounded
-                          : Icons.visibility_off_rounded,
-                    ),
-                    color: Colors.grey,
-                    onPressed: () => setState(() {
-                      _passwordVisible = !_passwordVisible;
-                    }),
+                      TextSpan(
+                        text: AppLocalizations.of(context)!
+                            .thankYouForParticipation,
+                      ),
+                    ],
                   ),
                 ),
-              ),
-              SizedBox(
-                width: 200,
-                child: PicosInkWellButton(
-                  onTap: () => _submitHandler(
-                    _loginController.text,
-                    _passwordController.text,
-                    context,
+                const SizedBox(
+                  height: 15,
+                ),
+                SizedBox(
+                  width: 200,
+                  child: PicosTextField(
+                    controller: _loginController,
+                    hint: AppLocalizations.of(context)!.username,
                   ),
-                  text: AppLocalizations.of(context)!.submit,
                 ),
-              ),
-              _loginfailure
-                  ? Text(AppLocalizations.of(context)!.wrongCredentials)
-                  : const Text(''),
-              const Padding(
-                padding: EdgeInsets.all(_sponsorLogoPadding),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: <Widget>[
-                    Expanded(
-                      child: Image(
-                        image: AssetImage('assets/BMBF.png'),
-                      ),
-                    ),
-                    SizedBox(width: _sponsorLogoPadding),
-                    Expanded(
-                      child: Image(
-                        image: AssetImage('assets/Logo_MII.png'),
-                      ),
-                    ),
-                  ],
+                const SizedBox(
+                  height: 10,
                 ),
-              ),
-            ],
+                SizedBox(
+                  width: 200,
+                  child: PicosTextField(
+                    controller: _passwordController,
+                    hint: AppLocalizations.of(context)!.password,
+                    obscureText: !_passwordVisible,
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _passwordVisible
+                            ? Icons.visibility_rounded
+                            : Icons.visibility_off_rounded,
+                      ),
+                      color: Colors.grey,
+                      onPressed: () => setState(() {
+                        _passwordVisible = !_passwordVisible;
+                      }),
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  width: 200,
+                  child: PicosInkWellButton(
+                    onTap: () => _submitHandler(
+                      _loginController.text,
+                      _passwordController.text,
+                      context,
+                    ),
+                    text: AppLocalizations.of(context)!.submit,
+                  ),
+                ),
+                _loginfailure
+                    ? Text(AppLocalizations.of(context)!.wrongCredentials)
+                    : const Text(''),
+                const Padding(
+                  padding: EdgeInsets.all(_sponsorLogoPadding),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Expanded(
+                        child: Image(
+                          image: AssetImage('assets/BMBF.png'),
+                        ),
+                      ),
+                      SizedBox(width: _sponsorLogoPadding),
+                      Expanded(
+                        child: Image(
+                          image: AssetImage('assets/Logo_MII.png'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -74,6 +74,12 @@ class _LoginScreenState extends State<LoginScreen>
   @override
   void initState() {
     super.initState();
+    SystemChrome.setSystemUIOverlayStyle(
+      SystemUiOverlayStyle(
+        statusBarColor: Theme.of(context).canvasColor,
+        statusBarIconBrightness: Brightness.dark,
+      ),
+    );
     _loginController = TextEditingController(text: '');
     _passwordController = TextEditingController(text: '');
     _passwordVisible = false;
@@ -86,18 +92,8 @@ class _LoginScreenState extends State<LoginScreen>
     super.dispose();
   }
 
-  void _setSystemNavigationBarColor(BuildContext context) {
-    SystemChrome.setSystemUIOverlayStyle(
-      SystemUiOverlayStyle(
-        statusBarColor: Theme.of(context).canvasColor,
-        statusBarIconBrightness: Brightness.dark,
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    _setSystemNavigationBarColor(context);
     return SafeArea(
       child: Scaffold(
         appBar: PreferredSize(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -101,7 +101,7 @@ class _LoginScreenState extends State<LoginScreen>
     return SafeArea(
       child: Scaffold(
         appBar: PreferredSize(
-          preferredSize: const Size.fromHeight(0.0), // here the desired height
+          preferredSize: const Size.fromHeight(0.0),
           child: AppBar(),
         ),
         body: Center(

--- a/lib/screens/questionaire_screen/questionaire_screen.dart
+++ b/lib/screens/questionaire_screen/questionaire_screen.dart
@@ -197,7 +197,6 @@ class _QuestionaireScreenState extends State<QuestionaireScreen> {
             _title ??= _pageStorage!.titles[0];
 
             return PicosScreenFrame(
-              appBarElevation: 0.0,
               title: _title,
               body: PageView(
                 controller: _controller,

--- a/lib/widgets/picos_screen_frame.dart
+++ b/lib/widgets/picos_screen_frame.dart
@@ -24,14 +24,10 @@ class PicosScreenFrame extends StatelessWidget {
   /// Creates PicosScreenFrame.
   const PicosScreenFrame({
     Key? key,
-    this.appBarElevation = 4,
     this.bottomNavigationBar,
     this.title,
     this.body,
   }) : super(key: key);
-
-  /// The setting for the App Bar Elevation (Shadow).
-  final double appBarElevation; 
 
   /// A Navigation bar displayed at the bottom.
   final Widget? bottomNavigationBar;
@@ -54,7 +50,6 @@ class PicosScreenFrame extends StatelessWidget {
           appBar: AppBar(
             centerTitle: true,
             title: Text(title ?? ''),
-            elevation: appBarElevation,
           ),
           body: body,
         ),


### PR DESCRIPTION
1. Match the color of the statusbar to the content
2. Change the Icons of the statusbar to be more visible
3. Disable the shadows of the app bar

So:
- fixes issue #136 

4. In this pull request, I have set the size of the app bar on the LoginScreen to zero:

![image](https://github.com/healthcare-it-solutions/picos/assets/132355030/385edd1f-a173-4064-9ed2-79326804b203)
