### PR TITLE
Release 1.13.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.12.0+19
+version: 1.13.0+20
 
 environment:
   sdk: ">=2.16.1 <3.17.0"


### PR DESCRIPTION
Adds:
- Constant link to the handbook

Fixes:
- Focus problem on study nurse pages on iPhone
- Delete-Button bug resolved