### PR TITLE
Reset minSdkVersion

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
 
     defaultConfig {
         applicationId "de.hitsolutions.picos"
-        minSdkVersion 21 // Should use flutter.minSdkVersion as soon as updated in Flutter.
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 34 // Should use flutter.targetSdkVersion as soon as updated in Flutter.
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.20.1+29
+version: 1.20.1+30
 
 environment:
   sdk: ">=2.16.1 <3.17.0"


### PR DESCRIPTION
- Google Play Console said that by changing "minSdkVersion" we are reducing the number of devices. This is why this reset:

![image](https://github.com/healthcare-it-solutions/picos/assets/132355030/9985db16-55c3-4c1b-9129-0914954ed2e4)
