### PR TITLE
Fix warning/enable OnBackInvokedCallback in manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
    <application
         android:label="picos"
         android:name="${applicationName}"
-        android:icon="@mipmap/launcher_icon">
+        android:icon="@mipmap/launcher_icon"
+        android:enableOnBackInvokedCallback="true">
         <!-- Meta-Data for Default Notification Channel -->
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"


### PR DESCRIPTION
When you log out you get this warning:

```
W/WindowOnBackDispatcher(11500): OnBackInvokedCallback is not enabled for the application.
W/WindowOnBackDispatcher(11500): Set 'android:enableOnBackInvokedCallback="true"' in the application manifest.
```
