### PR TITLE
Fix Submodule Configuration: Track Branch and Enable Automatic Merge

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "assets"]
 	path = assets
 	url = git@github.com:healthcare-it-solutions/picos-assets.git
+	branch = main # <-- track main
+    update = merge # <-- merge updates


### PR DESCRIPTION
This pull request addresses an issue where the submodule (Assets branch) was in a detached HEAD state. The`.gitmodules`file has been updated to track the`main`branch and automatically merge updates. This ensures that the submodule stays in sync with the latest changes from the main branch and avoids manual intervention when updating the submodule.