### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,7 +20,7 @@ jobs:
     - run: flutter test
     - run: flutter build apk
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: picos.apk
         path: build/app/outputs/flutter-apk/app-release.apk


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1ab1b8be-26bd-4eb9-a3f0-661246567ae2)

Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/