### PR TITLE
Typo in relatives list

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -36,7 +36,7 @@
   "mother": "Mutter",
   "brother": "Bruder",
   "sister": "Schwester",
-  "lifePartner": "Lebnspartner",
+  "lifePartner": "Lebenspartner",
   "edit": "Bearbeiten",
   "delete": "Löschen",
   "mr": "Herr",


### PR DESCRIPTION
Change `Lebnspartner ` to `Lebenspartner`