### PR TITLE
Bugfix/follow up save duplicate entries

### DIFF
--- a/lib/api/backend_follow_up_api.dart
+++ b/lib/api/backend_follow_up_api.dart
@@ -28,20 +28,27 @@ class BackendFollowUpApi extends BackendObjectsApi {
   @override
   Future<void> saveObject(AbstractDatabaseObject object) async {
     try {
-      FollowUp followUp = (object as FollowUp);
-
-      if (followUp.objectId == null) {
+      if ((object as FollowUp).objectId == null) {
         String roleId = await BackendRole.userRoleName.id;
         BackendACL followUpACL = BackendACL()
           ..setReadAccess(userId: EditPatientScreen.patientObjectId!)
           ..setReadAccess(userId: roleId)
           ..setWriteAccess(userId: roleId);
-        await Backend.saveObject(followUp, acl: followUpACL);
+        dynamic responseSave =
+            await Backend.saveObject(object, acl: followUpACL);
+        object = object.copyWith(
+          objectId: responseSave['objectId'],
+          createdAt: DateTime.tryParse(responseSave['createdAt']),
+        );
       } else {
-        await Backend.saveObject(followUp);
+        dynamic responseUpdate = await Backend.saveObject(object);
+        object = object.copyWith(
+          updatedAt: DateTime.tryParse(responseUpdate['updatedAt']),
+        );
       }
 
-      super.updateObjectList(followUp);
+      objectList[object.number!] = object;
+
       dispatch();
     } catch (e) {
       return Future<void>.error(e);

--- a/lib/screens/study_nurse_screen/follow_up_screen/follow_up_list.dart
+++ b/lib/screens/study_nurse_screen/follow_up_screen/follow_up_list.dart
@@ -40,7 +40,7 @@ class FollowUpList extends StatelessWidget {
 
     return BlocBuilder<ObjectsListBloc<BackendFollowUpApi>, ObjectsListState>(
       builder: (BuildContext context, ObjectsListState state) {
-        if (state.objectsList.isEmpty &&
+        if (state.status == ObjectsListStatus.initial ||
             state.status == ObjectsListStatus.loading) {
           return const Center(
             child: CircularProgressIndicator(),


### PR DESCRIPTION
**In FollowUp, if you save a 'V' that does not exist beforehand, then edit it and save it again, you will receive two entries in the backend for the same 'V'**


**To reproduce error:**

1. go to the follow-up of a patient
2. select a V that does not yet have an entry
3. make an entry and save
4. do not go back to the main screen, but select the same V in the follow up list as in 2.
5. change an entry and click on save