### PR TITLE
Prevent text from overlapping

### DIFF
--- a/lib/screens/home_screen/overview/widgets/input_card_section.dart
+++ b/lib/screens/home_screen/overview/widgets/input_card_section.dart
@@ -20,11 +20,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:picos/models/daily_input.dart';
 import 'package:picos/widgets/picos_ink_well_button.dart';
+import 'package:picos/widgets/picos_overflow_text.dart';
 
 import '../../../../state/objects_list_bloc.dart';
 import '../../../../themes/global_theme.dart';
 import '../../../../util/backend.dart';
-import '../../../../widgets/picos_overflow_text.dart';
 import 'mini_calendar.dart';
 
 /// This class implements the top section of the 'overview'.

--- a/lib/screens/home_screen/overview/widgets/input_card_section.dart
+++ b/lib/screens/home_screen/overview/widgets/input_card_section.dart
@@ -24,6 +24,7 @@ import 'package:picos/widgets/picos_ink_well_button.dart';
 import '../../../../state/objects_list_bloc.dart';
 import '../../../../themes/global_theme.dart';
 import '../../../../util/backend.dart';
+import '../../../../widgets/picos_overflow_text.dart';
 import 'mini_calendar.dart';
 
 /// This class implements the top section of the 'overview'.
@@ -63,8 +64,8 @@ class InputCardSection extends StatelessWidget {
           children: <Widget>[
             Row(
               children: <Widget>[
-                Text(
-                  AppLocalizations.of(context)!.myEntries,
+                PicosOverflowText(
+                  text: AppLocalizations.of(context)!.myEntries,
                   style: TextStyle(
                     fontSize: 23,
                     color: theme.darkGreen1,

--- a/lib/screens/home_screen/overview/widgets/progress_tile.dart
+++ b/lib/screens/home_screen/overview/widgets/progress_tile.dart
@@ -23,6 +23,7 @@ import 'package:picos/models/daily_input.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../../../themes/global_theme.dart';
+import '../../../../widgets/picos_overflow_text.dart';
 
 /// A list tile for showing the questionnaire progress.
 class ProgressTile extends StatelessWidget {
@@ -206,8 +207,8 @@ class ProgressTile extends StatelessWidget {
           const SizedBox(
             height: 5,
           ),
-          Text(
-            title,
+          PicosOverflowText(
+            text: title,
             style: TextStyle(
               color: theme.white,
               fontSize: 16,

--- a/lib/screens/home_screen/overview/widgets/progress_tile.dart
+++ b/lib/screens/home_screen/overview/widgets/progress_tile.dart
@@ -21,9 +21,9 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:picos/models/daily_input.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:picos/widgets/picos_overflow_text.dart';
 
 import '../../../../themes/global_theme.dart';
-import '../../../../widgets/picos_overflow_text.dart';
 
 /// A list tile for showing the questionnaire progress.
 class ProgressTile extends StatelessWidget {

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -27,6 +27,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:picos/widgets/picos_text_field.dart';
 import 'package:upgrader/upgrader.dart';
 
+import '../widgets/picos_overflow_text.dart';
+
 ///Displays the login screen.
 class LoginScreen extends StatefulWidget {
   ///LoginScreen constructor.
@@ -142,12 +144,11 @@ class _LoginScreenState extends State<LoginScreen>
               const SizedBox(
                 height: 15,
               ),
-              _backendError != null
-                  ? Text(
-                      _backendError!.getMessage(context),
-                      style: TextStyle(color: theme.red),
-                    )
-                  : const Text(''),
+              if (_backendError != null)
+                Text(
+                  _backendError!.getMessage(context),
+                  style: TextStyle(color: theme.red),
+                ),
               const SizedBox(
                 height: 15,
               ),
@@ -206,30 +207,22 @@ class _LoginScreenState extends State<LoginScreen>
                 width: 200,
                 child: Row(
                   children: <Widget>[
-                    !kIsWeb
-                        ? Text(AppLocalizations.of(context)!.rememberMe)
-                        : const SizedBox(
-                            width: 0,
-                          ),
-                    Expanded(
-                      child: !kIsWeb
-                          ? Checkbox(
-                              value: _isChecked,
-                              checkColor: theme.white,
-                              activeColor: theme.darkGreen1,
-                              onChanged: (bool? value) {
-                                setState(
-                                  () {
-                                    _isChecked = value!;
-                                    _secureStorage.setIsChecked(_isChecked);
-                                  },
-                                );
-                              },
-                            )
-                          : const SizedBox(
-                              width: 0,
-                            ),
-                    ),
+                    if (!kIsWeb) ...<Widget>[
+                      PicosOverflowText(
+                        text: AppLocalizations.of(context)!.rememberMe,
+                      ),
+                      Checkbox(
+                        value: _isChecked,
+                        checkColor: theme.white,
+                        activeColor: theme.darkGreen1,
+                        onChanged: (bool? value) {
+                          setState(() {
+                            _isChecked = value!;
+                            _secureStorage.setIsChecked(_isChecked);
+                          });
+                        },
+                      ),
+                    ],
                   ],
                 ),
               ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -26,8 +26,7 @@ import 'package:picos/widgets/picos_screen_frame.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:picos/widgets/picos_text_field.dart';
 import 'package:upgrader/upgrader.dart';
-
-import '../widgets/picos_overflow_text.dart';
+import 'package:picos/widgets/picos_overflow_text.dart';
 
 ///Displays the login screen.
 class LoginScreen extends StatefulWidget {

--- a/lib/widgets/picos_overflow_text.dart
+++ b/lib/widgets/picos_overflow_text.dart
@@ -1,0 +1,48 @@
+/*   This file is part of Picos, a health tracking mobile app
+*    Copyright (C) 2022 Healthcare IT Solutions GmbH
+*
+*    This program is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    This program is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import 'package:flutter/material.dart';
+
+/// A text widget that automatically applies ellipsis overflow handling
+/// and wraps the text in a [Flexible] widget to prevent layout issues.
+class PicosOverflowText extends StatelessWidget {
+  /// Creates a [PicosOverflowText] widget.
+  ///
+  /// The [text] parameter must not be null.
+  const PicosOverflowText({
+    required this.text,
+    Key? key,
+    this.style,
+  }) : super(key: key);
+
+  /// The text to display.
+  final String text;
+
+  /// The style to apply to the text.
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Flexible(
+      child: Text(
+        text,
+        style: style,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 🐛 Problem
- If the font size in the smartphone is set to maximum, the “Remember me” text in the login screen overlaps the checkbox so that it could not be tapped.
- This affects the 14-day overview on the overview screen.

### ✅ Solution
- Apply Overflow: “TextOverflow.ellipsi“ to keep the layout stable 
- Use the Widget “Flexible“