### PR TITLE
fix: replace deprecated serviceWorkerVersion with Flutter token

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -37,7 +37,7 @@
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
+    var serviceWorkerVersion = '{{flutter_service_worker_version}}';
     var scriptLoaded = false;
     function loadMainDartJs() {
       if (scriptLoaded) {


### PR DESCRIPTION
### 🔧 **What was changed?**

Replaced the deprecated local variable `serviceWorkerVersion` in `index.html` with the recommended `{{flutter_service_worker_version}}` template token.

---

### 📚 **Context**

Flutter now recommends using the `{{flutter_service_worker_version}}` template token instead of hardcoding the `serviceWorkerVersion` variable. This change aligns with best practices for Flutter web initialization and prevents build-time warnings.

Reference:  
[[Flutter Web Initialization – Service Worker Version](https://docs.flutter.dev/platform-integration/web/initialization)](https://docs.flutter.dev/platform-integration/web/initialization)

---

### ✅ **Why is this important?**

- Removes deprecation warning during build
- Ensures correct service worker version is injected by Flutter
- Prevents caching issues in production

---

### 🧪 **Testing**

- Manually tested in the browser
- Confirmed that no warnings appear during `flutter build web`
- Verified app behavior remains unchanged

