### PR TITLE
Release 1.22.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.22.2+34
+version: 1.22.3+35
 
 environment:
   sdk: ">=2.16.1 <3.17.0"


### PR DESCRIPTION
Bugfixes:

 - PICOS app: Prevent text from overlapping
 - Intern warning: Replace deprecated serviceWorkerVersion with Flutter token