### PR TITLE
Release 1.22.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.22.4+36
+version: 1.22.5+37
 
 environment:
   sdk: ">=2.16.1 <3.17.0"


### PR DESCRIPTION
- The following changes were made with the migration to the new version of Flutter (3.35.1):
  - Bugfix for Android with the animation of “My Values”
  - Support for 16 KB page size for Android
  - Adjustment of used functions
  - Rename deprecated variables

- Coderefactoring

